### PR TITLE
update rel velocity model to neows

### DIFF
--- a/lib/neows/models/relative_velocity.rb
+++ b/lib/neows/models/relative_velocity.rb
@@ -7,7 +7,7 @@ module Neows
       # @!attribute [rw]
       # @return [Float]
       attribute :kilometers_per_second, Float
-      alias_method :kps, :kilometers_per_second
+      alias_method :kms, :kilometers_per_second
 
       # @!attribute [rw]
       # @return [Float]

--- a/lib/neows/models/relative_velocity.rb
+++ b/lib/neows/models/relative_velocity.rb
@@ -7,14 +7,17 @@ module Neows
       # @!attribute [rw]
       # @return [Float]
       attribute :kilometers_per_second, Float
+      alias_method :kps, :kilometers_per_second
 
       # @!attribute [rw]
       # @return [Float]
       attribute :kilometers_per_hour, Float
+      alias_method :kph, :kilometers_per_hour
 
       # @!attribute [rw]
       # @return [Float]
       attribute :miles_per_hour, Float
+      alias_method :mph, :miles_per_hour
     end
   end
 end

--- a/lib/neows/models/relative_velocity.rb
+++ b/lib/neows/models/relative_velocity.rb
@@ -6,15 +6,15 @@ module Neows
     class RelativeVelocity < Neows::Models::BaseModel
       # @!attribute [rw]
       # @return [Float]
-      attribute :kms, Float
+      attribute :kilometers_per_second, Float
 
       # @!attribute [rw]
       # @return [Float]
-      attribute :kph, Float
+      attribute :kilometers_per_hour, Float
 
       # @!attribute [rw]
       # @return [Float]
-      attribute :mph, Float
+      attribute :miles_per_hour, Float
     end
   end
 end

--- a/lib/neows/version.rb
+++ b/lib/neows/version.rb
@@ -1,3 +1,3 @@
 module Neows
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/spec/fixtures/relative_velocity.json
+++ b/spec/fixtures/relative_velocity.json
@@ -1,5 +1,5 @@
 {
-  "kms": "6.57260631740581",
-  "kph": "23661.383",
-  "mph": "14702.263"
+  "kilometers_per_second": "6.57260631740581",
+  "kilometers_per_hour": "23661.383",
+  "miles_per_hour": "14702.263"
 }

--- a/spec/models/relative_velocity_spec.rb
+++ b/spec/models/relative_velocity_spec.rb
@@ -4,8 +4,11 @@ describe Neows::Models::RelativeVelocity do
   subject { described_class.new json_fixture('/relative_velocity.json') }
 
   it 'correctly assigns data to attributes' do
-    expect(subject.kms).to eq 6.57260631740581
+    expect(subject.kilometers_per_second).to eq 6.57260631740581
+    expect(subject.kps).to eq 6.57260631740581
+    expect(subject.kilometers_per_hour).to eq 23661.383
     expect(subject.kph).to eq 23661.383
+    expect(subject.miles_per_hour).to eq 14702.263
     expect(subject.mph).to eq 14702.263
   end
 end

--- a/spec/models/relative_velocity_spec.rb
+++ b/spec/models/relative_velocity_spec.rb
@@ -5,7 +5,7 @@ describe Neows::Models::RelativeVelocity do
 
   it 'correctly assigns data to attributes' do
     expect(subject.kilometers_per_second).to eq 6.57260631740581
-    expect(subject.kps).to eq 6.57260631740581
+    expect(subject.kms).to eq 6.57260631740581
     expect(subject.kilometers_per_hour).to eq 23661.383
     expect(subject.kph).to eq 23661.383
     expect(subject.miles_per_hour).to eq 14702.263


### PR DESCRIPTION
relative velocity values were update in NeoWs. Updating model to match

from:
relative_velocity: {
kps: "5.36",
kph: "19280.19",
mph: "11979.96"
},

to:
relative_velocity: {
kilometers_per_second: "5.36",
kilometers_per_hour: "19280.19",
miles_per_hour: "11979.96"
},
